### PR TITLE
12-18

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -5,7 +5,6 @@ export default{
   data() {
         return {
           showDropdown: false,
-          userEmail: localStorage.getItem('UserEmail'),
         };
     },
     computed:{

--- a/src/components/content/child/siteElement.vue
+++ b/src/components/content/child/siteElement.vue
@@ -11,7 +11,9 @@
         <div class="content-cell">
             <div class="status-buttons">
                 <div class="status-label">무료버전</div>
-                <button class="status-button active">연장/업그레이드</button>
+                <router-link :to="{path: '/pay', query: { siteId: site.siteId }}">
+                  <button class="status-button active">연장/업그레이드</button>
+                </router-link>
             </div>
         </div>
         <div class="content-cell">
@@ -60,7 +62,7 @@ export default {
         },
         deleteSite(){
           //const userEmail = this.userStore.userEmail;
-          const userEmail = localStorage.getItem('email');
+          const userEmail = this.userStore.userData.userEmail;
           console.log(userEmail);
           console.log(this.site.siteId);
 
@@ -69,6 +71,7 @@ export default {
                 )
                 .then(response => {
                   console.log("성공");
+                  window.location.reload();
                 })
                 .catch(error => {
                 });

--- a/src/components/content/login.vue
+++ b/src/components/content/login.vue
@@ -94,8 +94,7 @@ export default {
                             //localStorage.setItem('image', response.data.imgUrl);
                             //userStore.setUserData(this.email, );
                             const randomValue = Math.floor(Math.random() * 20) + 1;
-                            const imageName = `${randomValue}.png`;
-                            localStorage.setItem('image', imageName);
+
                             this.$router.push('/'); //메인 페이지로 이동
                         }
                     }

--- a/src/components/content/modal/createSite.vue
+++ b/src/components/content/modal/createSite.vue
@@ -1,9 +1,15 @@
 <script>
 import axios from 'axios';
+import { useUserStore } from '@/Store/userLoginStore';
 
 export default {
     props:{
         templateId: Number,
+    },
+    computed:{
+        userStore(){
+            return useUserStore();
+        }
     },
     methods: {
         clearSiteName() {
@@ -17,19 +23,22 @@ export default {
         },
         createSite(){
             const param = {
-                email: localStorage.getItem('email'),
+                email: this.userStore.userData.userEmail,
                 siteName: this.$refs.inputSiteName.value,
+                url: this.$refs.inputSiteDomain.value,
             }
 
             axios.post(`http://192.168.5.10:8888/고객/회원/사이트생성`, param,
                 { withCredentials: true })
                 .then(response => {
-                    if (response == 200){
+                    console.log(response);
+                    if (response.status == 200){
                         console.log("성공!!");
                         this.$router.push("/mySite");
                     }
                 })
                 .catch(error => {
+                    console.log(error);
                     console.log("실패!!");
                 });
         }
@@ -156,7 +165,10 @@ export default {
         }
 
         .domain-suffix {
-            padding: 12px;
+            display: flex; /* Flexbox 활성화 */
+            justify-content: flex-start; /* 내부 요소를 왼쪽 정렬 */
+            align-items: center; /* 세로 중앙 정렬 */
+            padding: 12px 30px;
             color: rgba(255, 255, 255, 0.5);
             font-size: 14px;
             border-left: 1px solid rgba(255, 255, 255, 0.2);

--- a/src/components/content/myPage.vue
+++ b/src/components/content/myPage.vue
@@ -55,7 +55,7 @@ export default{
         <!-- 정보수정 섹션 -->
         <div class="section-info">
             <div class="section-header">
-                <h2>정보수정</h2>
+                <h2>내 정보</h2>
                 <router-link :to="{path: '/editPage', query: { activeTab: 'info' }}">
                     <button class="nav-button">수정하기</button>
                 </router-link>
@@ -184,6 +184,7 @@ export default{
 .profile-info-inline {
     display: flex;
     flex-direction: column;
+    padding-left: 30px;
 }
 
 .nickname {

--- a/src/components/content/pay.vue
+++ b/src/components/content/pay.vue
@@ -9,15 +9,30 @@ export default {
         selectedPeriod: '1',
         defaultPrice: 1,
         siteList: [],
-        selectedSite: [],
+        selectedSite: null,
     }
   },
     mounted() {
         initializeIMP();
-        const getList = localStorage.getItem('siteList');
-        this.siteList = JSON.parse(getList);
 
-        localStorage.removeItem('siteList');
+        axios.get(`http://192.168.5.10:8888/고객/회원/사이트정보/${this.userStore.userData.userEmail}`,
+        { withCredentials: true })
+        .then(response => {
+            console.log(response);
+            this.siteList = response.data.SiteList || []; // 데이터 할당
+            console.log(this.siteList);
+
+            this.siteList.forEach(element => {
+                if(element.siteId == this.$route.query.siteId){
+                  this.selectedSite = element;
+                }
+                
+            });
+        })
+        .catch(error => {
+            console.log(error);
+        });
+
     },
     computed:{
         userStore(){


### PR DESCRIPTION
- 개인정보 수정 시 링크 이동✅
- 개인정보 수정 시 피니아 재 설정✅
    1.PNG, JPG 외에 이미지 파일 확장자 설정 -희준이랑 상의 후 결정
    2.혹은 프론트에서 확장자 제한 안내 문구 - 희준이랑 상의 후 결정
    - 2번 방안으로 결정

- 전화번호 - 폼으로 변경✅
- 개인정보 수정 - 이메일 상단으로 변경~~✅
- 사이트 개설시 url 리셋 겹침                           → 장희준✅
- 사이트 url 컬럼 만들고 url 중복 확인            → 장희준✅
- 내 사이트 더보기 누른 후 외부 클릭시 드롭박스 닫기
-내 사이트 긁어 오기✅
    - 새로운 버그
    - 사이트 삭제 이후 해당 유저 안지워져서 나오는 버그✅
        - 해결 is_delete 컬럼을 생성하여 소프트 딜리트 구현
- 내 사이트 체크 ⚠️✅
- 마이페이지 내 정보 - 이름 수정✅
- 정보수정✅
    - 이미지와 이름, 이메일 간격 띄우기✅
- 이미지 등 회사 색 사용.

 👾**버그**

-결제하기 갈 때 사이트가 안보이는 경우가 있음. ✅
-사이트 삭제할 때 해당하는 사이트 만 삭제해야하는데 순서대로 다 사라짐. → 장희준✅
-사이트 생성시 이메일이 null로 들어감✅
- 유저 관련해서 버그 생기던 문제도 해결 완료 ✅
    - 사이트 생성시 생성된 유저를 삭제해 주지 않아서 0site값을 가진 유저가 존재하여 다음 유저 더미가 생성되지 않음